### PR TITLE
Fix Linux build missing definition of 'realpath'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD_DIR=build
 CC=gcc
 INCLUDE=-Isrc -I src/parse
 OPTIONS=-Wall -Werror -Wno-unused -std=c99 -pedantic -Wstrict-aliasing \
-	-Wstrict-aliasing=2 -Wmissing-field-initializers $(INCLUDE)
+	-Wstrict-aliasing=2 -Wmissing-field-initializers -D_XOPEN_SOURCE=500 $(INCLUDE)
 VERSION_FILE=$(BUILD_DIR)/version.c
 
 .PHONY: all pre-build dev dev-pre-build clean


### PR DESCRIPTION
According to https://man7.org/linux/man-pages/man3/realpath.3.html, _XOPEN_SOURCE >= 500 in order to use realpath, and trying to compile without it on Linux using gcc 12 results in a
-Werror=implicit-function-declaration error. Instead, add this define which enables using 'realpath' to the compiler options.